### PR TITLE
fix(filepath): enable filepaths with dots in foldername

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,11 +19,11 @@ export function activate(context: vscode.ExtensionContext) {
             "Input not of format: width[x]height"
           );
         } else {
-          let resizedImageLocationParts = filePath.fsPath.split(".");
+          let resizedImageLocationParts = filePath.fsPath.split(/(?:\.)([^\/]*)$/g);
           jimp
             .read(filePath.fsPath)
             .then(function (image) {
-              // if one of the dimentions is set to "auto" it'll be auto scaled. 
+              // if one of the dimentions is set to "auto" it'll be auto scaled.
               var width = resizeDimensions[0].toLowerCase() == 'auto' ? jimp.AUTO : Number.parseInt(resizeDimensions[0]);
               var height = resizeDimensions[1].toLowerCase() == 'auto' ? jimp.AUTO : Number.parseInt(resizeDimensions[1]);
               image


### PR DESCRIPTION
Hi Luka,
I changed the pattern to split the file path to use a Regular Expression, so that the extension now can handle dots in foldernames. Happened to me, when I tried to resize images for my github.io repo.
Would be nice, If you could review this change and maybe merge it into your project!

Greetings,

Stefan